### PR TITLE
Fixed #46  layout of signup page with care of responsiveness for all screen

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -45,10 +45,10 @@ function Page() {
       <div>
         <Toaster />
       </div>
-      <section>
-        <div className="grid grid-cols-1 lg:grid-cols-2">
-          <div className="flex items-center justify-center px-4 py-10 sm:px-6 sm:py-16 lg:px-8 lg:py-24">
-            <div className="xl:mx-auto xl:w-full xl:max-w-sm 2xl:max-w-md">
+      <section className="p-10">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
+          <div className="flex items-center justify-center px-4 py-6 sm:px-6 sm:py-16 lg:px-8 lg:py-24">
+            <div className="xl:mx-auto xl:w-full xl:max-w-sm 2xl:max-w-md w-[75vw]">
               <h2 className="text-3xl font-bold leading-tight text-black sm:text-4xl">
                 Log in
               </h2>

--- a/src/components/component/Footer.tsx
+++ b/src/components/component/Footer.tsx
@@ -31,7 +31,7 @@ export function Footer() {
     
   }
   return (
-    <footer className="w-full">
+    <footer className="w-full px-3">
       <div>
         <Toaster/>
       </div>


### PR DESCRIPTION
Before The Signup Page was looking like this

![before](https://github.com/user-attachments/assets/0a4db607-fb58-4bba-a386-51045afda1cd)

now after adding some padding and margin with the care of responsiveness for all screen it's look like 

laptop 
![Afterlap](https://github.com/user-attachments/assets/14d31595-36a8-4fab-9ce3-281da61fd0c0)

tab
![aftertab](https://github.com/user-attachments/assets/b731ede3-9130-4e35-9655-774efd6f8b10)

mobile
![aftermob](https://github.com/user-attachments/assets/c1f9af0a-822d-4e2a-92f1-de41bd68864f)
